### PR TITLE
Update pillow.py for indexed color spaces

### DIFF
--- a/pdfreader/pillow.py
+++ b/pdfreader/pillow.py
@@ -68,7 +68,7 @@ class PILImageMixin(object):
             # FlateDecode and others
             if isinstance(self.ColorSpace, Array):
                 cs = self.ColorSpace
-                my_cs, base_cs, hival, lookup = cs[0], cs[1], cs[2], cs[3].filtered
+                my_cs, base_cs, hival, lookup = cs[0], cs[1], cs[2], cs[3].to_bytes()
 
                 if my_cs == 'Indexed':
                     img = Image.new("P", size)


### PR DESCRIPTION
Changed .filtered to .to_bytes() because HexString lacks .filtered, and Pillow expects the palette data to be a list of integers.